### PR TITLE
Align schedule

### DIFF
--- a/src/main/resources/css/views/_schedule.scss
+++ b/src/main/resources/css/views/_schedule.scss
@@ -9,6 +9,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-evenly;
+    gap: 32px;
   }
 
   .timeslot {
@@ -23,8 +24,7 @@
     }
   
     .talk-card,
-    .blank-card,
-    .empty-card {
+    .blank-card {
       flex: 1;
       min-width: min(250px, 100%);
     }
@@ -97,6 +97,41 @@
 
 .schedule.large {
   @extend %schedule;
+
+  display: grid;
+  grid-template-columns: 100px 1fr 1fr;
+
+  .tab {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .times {
+    position: relative;
+
+    div {
+      position: absolute;
+    }
+  }
+
+  > div:nth-child(5) {
+    grid-column: span 2;
+    display: flex;
+  }
+
+  .content {
+    flex: 1;
+    position: relative;
+    margin: 16px 0;
+
+    .card {
+      position: absolute;
+      width: calc(100% - 32px);
+      > div {
+        height: 100%;
+      }
+    }
+  }
 
   width: min(100%, 1000px);
   margin: 0 auto;

--- a/src/main/scala/io/scala/data/ScheduleInfo.scala
+++ b/src/main/scala/io/scala/data/ScheduleInfo.scala
@@ -182,11 +182,11 @@ object ScheduleInfo {
       start = Time(18, 35),
       kind = Special.Kind.End
     ),
-    Special(
-      day = ConfDay.Thursday,
-      start = Time(19, 30),
-      kind = Special.Kind.CommunityParty
-    ),
+    // Special(
+    //   day = ConfDay.Thursday,
+    //   start = Time(19, 30),
+    //   kind = Special.Kind.CommunityParty
+    // ),
     Break(
       day = ConfDay.Friday,
       start = Time(9, 45),
@@ -239,8 +239,9 @@ object ScheduleInfo {
     )
   )
 
-  val minStart      = Time(9, 0)
-  val maxStart      = Time(18, 20)
+  val minStart           = Time(9, 0)
+  val maxEnd             = Time(19, 0)
+  val pxByHour           = 500
   lazy val blankSchedule = blankTalks ++ breaks
   lazy val schedule      = allTalks ++ breaks
 }

--- a/src/main/scala/io/scala/domaines/Talk.scala
+++ b/src/main/scala/io/scala/domaines/Talk.scala
@@ -31,10 +31,7 @@ enum Room extends TalkInfo[Room]:
   def render = "Room " + this.ordinal
 
 case class Time(h: Int, m: Int) {
-  def +(minutes: Int): Time =
-    val ending = m + minutes
-    if ending >= 60 then Time(h + 1, ending - 60)
-    else Time(h, ending)
+  val toHour = h + m / 60.0
   def render(tag: HtmlTag[dom.html.Element] = div) = tag(
     span(
       f"$h%02d",
@@ -134,12 +131,16 @@ case class Break(
 ) extends Event
     with Durable:
   def duration: Int = kind.duration
-  def render        = div(className := "blank-card", kind.toIcon, kind.toIcon)
+  def render        = div(className := s"blank-card ${kind.toStyle}", kind.toIcon, kind.toIcon)
 
 object Break:
   enum Kind:
     case Coffee, Large, Launch
 
+    def toStyle = this match
+      case Coffee => "break-coffee"
+      case Large  => "break-large"
+      case Launch => "break-launch"
     def toIcon = this match
       case Coffee => svgs.Coffee()
       case Large  => svgs.Chat()

--- a/src/main/scala/io/scala/modules/TalkCard.scala
+++ b/src/main/scala/io/scala/modules/TalkCard.scala
@@ -14,7 +14,7 @@ object TalkKindTag:
     span(kind.toString, className := kind.toStyle)
 object TalkDescription:
   def apply(description: String) =
-    val desc = if (description.length() <= 200) description else description.substring(0, 200) + "..."
+    val desc = if (description.length() <= 150) description else description.substring(0, 150) + "..."
     p(desc)
 
 object TalkCard:


### PR DESCRIPTION
Aligned schedule in a calendar-like way. There are still some things to be done
- [  ] fix alignement of timeslot between day 1 and 2 (due to one break in day 2 that adds 32px of margin)
- [  ] find how to handle short/lightning talks
