### PR TITLE
Sort categories dynamically

### DIFF
--- a/src/main/scala/io/scala/Page.scala
+++ b/src/main/scala/io/scala/Page.scala
@@ -33,7 +33,7 @@ enum BasicPage(val view: GenericView):
   }
 
   case Index    extends BasicPage(IndexView)
-  case Talks    extends BasicPage(TalksList)
+  case Talks    extends BasicPage(TalkList)
   case Sponsors extends BasicPage(SponsorsList)
   case Venue    extends BasicPage(VenueView)
   case Schedule extends BasicPage(ScheduleView)

--- a/src/main/scala/io/scala/domaines/Talk.scala
+++ b/src/main/scala/io/scala/domaines/Talk.scala
@@ -134,7 +134,8 @@ case class Break(
 ) extends Event
     with Durable:
   def duration: Int = overrideDuration.getOrElse(kind.duration)
-  def render        = div(className := s"blank-card break ${kind.toStyle}", kind.toIcon, span(span(duration), span("min")), kind.toIcon)
+  def render =
+    div(className := s"blank-card break ${kind.toStyle}", kind.toIcon, span(span(duration), span("min")), kind.toIcon)
 
 object Break:
   enum Kind:
@@ -143,15 +144,15 @@ object Break:
     def toStyle = this match
       case Coffee => "break-coffee"
       case Large  => "break-large"
-      case Lunch => "break-lunch"
+      case Lunch  => "break-lunch"
     def toIcon = this match
       case Coffee => svgs.Coffee()
       case Large  => svgs.Chat()
-      case Lunch => svgs.Food()
+      case Lunch  => svgs.Food()
     def duration = this match
       case Coffee => 5
       case Large  => 15
-      case Lunch => 60
+      case Lunch  => 60
   object Kind:
     val max: Int = Kind.values.map(_.duration).max
 

--- a/src/main/scala/io/scala/domaines/Talk.scala
+++ b/src/main/scala/io/scala/domaines/Talk.scala
@@ -110,7 +110,7 @@ object Talk:
       case Community      => "Community"
       case ToolsEcosystem => "Tools & Ecosystems"
       case Effects        => "Concurrent programming"
-      case Modeling       => "Modeling / Domain Modeling"
+      case Modeling       => "Modeling"
       case Cloud          => "Cloud"
       case AI             => "Artificial Intelligence"
 

--- a/src/main/scala/io/scala/domaines/Talk.scala
+++ b/src/main/scala/io/scala/domaines/Talk.scala
@@ -1,13 +1,14 @@
 package io.scala.domaines
 
+import io.scala.modules.TalkCard
 import io.scala.svgs
 import io.scala.svgs.Logo
+
 import com.raquo.laminar.api.L.{*, given}
 import com.raquo.laminar.nodes.ReactiveHtmlElement
 import com.raquo.laminar.tags.HtmlTag
 import org.scalajs.dom
 import org.scalajs.dom.HTMLDivElement
-import io.scala.modules.TalkCard
 
 sealed trait TalkInfo[A <: TalkInfo[A]]:
   def ordinal: Int
@@ -68,6 +69,7 @@ case class Talk(
   lazy val renderDescription = description.split("\n").map(p(_))
   def duration: Int          = kind.duration
   def render                 = TalkCard(this)
+  def isKeynote: Boolean     = kind == Talk.Kind.Keynote
 
 object Talk:
   enum Kind:

--- a/src/main/scala/io/scala/views/TalkList.scala
+++ b/src/main/scala/io/scala/views/TalkList.scala
@@ -8,27 +8,46 @@ import io.scala.modules.elements.*
 import com.raquo.laminar.api.L.{*, given}
 
 case object TalkList extends SimpleView {
-  private def bodyContent(talks: List[Talk]) = sectionTag(
-    className := "container talks-list",
-    Title("Talks"),
-    Line(margin = 55),
-    div(
-      className := "with-toc r-toc",
-      stickScroll,
+
+  private def sortedCategories(talks: List[Talk]): List[(Talk.Category, List[Talk])] =
+    talks
+      .groupBy(_.category)
+      .toList
+      .sortWith:
+        case ((cat1, talks1), (cat2, talks2)) =>
+          val cat1HasKeynote = talks1.exists(_.isKeynote)
+          val cat2HasKeynote = talks2.exists(_.isKeynote)
+          (cat1HasKeynote, cat2HasKeynote, talks1.size == talks2.size) match
+            // 1st criterion: categories with keynotes
+            case (false, true, _) => false
+            case (true, false, _) => true
+            // 2nd criterion: categories with more talks
+            case (_, _, false)    => talks1.size > talks2.size
+            // 3rd criterion: lexicographic order
+            case (_, _, true)     => cat1.name < cat2.name
+
+  private def bodyContent(allTalks: List[Talk]) =
+    val categories = sortedCategories(allTalks)
+    sectionTag(
+      className := "container talks-list",
+      Title("Talks"),
+      Line(margin = 55),
       div(
-        className := "content",
-        Talk.Category.values
-          .flatMap: category =>
-            Array(
+        className := "with-toc r-toc",
+        stickScroll(categories.map(_._1)),
+        div(
+          className := "content",
+          categories.flatMap: (category, talks) =>
+            List(
               h2(idAttr := category.slug, className := "content-title", category.name),
               div(
-                talks.filter(_.category == category).sortBy(_.title).map(TalkCard(_)),
+                talks.sortBy(_.title).map(TalkCard(_)),
                 className := "card-container"
               )
             )
+        )
       )
     )
-  )
 
   override def body(withDraft: Boolean): HtmlElement =
     if withDraft then bodyContent(TalksInfo.allTalks)
@@ -36,18 +55,19 @@ case object TalkList extends SimpleView {
 
   override def title: String = "Talks"
 
-  private def stickScroll =
+  private def stickScroll(sortedCategories: List[Talk.Category]) =
     div(
       className := "table-of-contents",
       idAttr    := "talks-cat-toc",
       div(
         className := "toc-content",
         h3("Navigation"),
-        Talk.Category.values.map: cat =>
+        sortedCategories.map: cat =>
           a(
             href := s"#${cat.slug}",
             span(s"- ${cat.name}")
           )
       )
     )
+
 }

--- a/src/main/scala/io/scala/views/TalkList.scala
+++ b/src/main/scala/io/scala/views/TalkList.scala
@@ -7,7 +7,7 @@ import io.scala.modules.elements.*
 
 import com.raquo.laminar.api.L.{*, given}
 
-case object TalksList extends SimpleView {
+case object TalkList extends SimpleView {
   def bodyContent(talks: List[Talk]) = sectionTag(
     className := "container talks-list",
     Title("Talks"),

--- a/src/main/scala/io/scala/views/TalkList.scala
+++ b/src/main/scala/io/scala/views/TalkList.scala
@@ -8,7 +8,7 @@ import io.scala.modules.elements.*
 import com.raquo.laminar.api.L.{*, given}
 
 case object TalkList extends SimpleView {
-  def bodyContent(talks: List[Talk]) = sectionTag(
+  private def bodyContent(talks: List[Talk]) = sectionTag(
     className := "container talks-list",
     Title("Talks"),
     Line(margin = 55),
@@ -30,13 +30,13 @@ case object TalkList extends SimpleView {
     )
   )
 
-  def body(withDraft: Boolean): HtmlElement =
+  override def body(withDraft: Boolean): HtmlElement =
     if withDraft then bodyContent(TalksInfo.allTalks)
     else bodyContent(TalksInfo.allTalks.filter(_.speakers.forall(_.confirmed)))
 
-  def title = "Talks"
+  override def title: String = "Talks"
 
-  def stickScroll =
+  private def stickScroll =
     div(
       className := "table-of-contents",
       idAttr    := "talks-cat-toc",


### PR DESCRIPTION
Categories with keynotes first, then categories with more talks. If equality, use lexicographical order.