### PR TITLE
Refactoring & fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val root = project
   .settings(
     name := "scalaio-website",
     scalacOptions ++= Seq(
-      // "-Yexplicit-nulls",
+      "-Yexplicit-nulls",
       "-Wunused:all",
 
     ),

--- a/public/conferences/nantes-2024/armored-type-safety-with-iron.md
+++ b/public/conferences/nantes-2024/armored-type-safety-with-iron.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: armored-type-safety-with-iron
 - Category: Modeling
+- confirmed: true
 - DateTime: 2024-02-15T11:40
 - Room: 0
 - Slides: https://scalaio-2024.rlemaitre.com
@@ -26,7 +27,6 @@ In this talk, we’ll show first the different technique we can use to apply con
 
 - photoRelPath: /images/profiles/nantes-2024/rLemaitre.webp
 - job: Senior Staff Engineer @ Ledger
-- confirmed: true
 
 #### Links
 
@@ -51,7 +51,6 @@ My interests span from software development to history and technology, where I e
 
 - photoRelPath: /images/profiles/nantes-2024/vBergeron.webp
 - job: Engineering team lead @ Ledger
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/chasing-arrows-functors-monads.md
+++ b/public/conferences/nantes-2024/chasing-arrows-functors-monads.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: chasing-arrows-functors-monads
 - Category: Algebra
+- confirmed: true
 - DateTime: 2024-02-16T15:40
 - Room: 0
 - Slides: https://scala.io/slides/2024/chasing-arrows.pdf
@@ -29,7 +30,6 @@ This ScalaIO talk will be a overview of the EPITA CT4P course, with emphasis on 
 
 - photoRelPath: /images/profiles/nantes-2024/jim.webp
 - job: Researcher @ EPITA Le Kremlin-Bicêtre
-- confirmed: true
 
 #### Links
 
@@ -50,7 +50,6 @@ Jim has been programming off and on in Scala for about 5 years.
 
 - photoRelPath: /images/profiles/nantes-2024/uli.webp
 - job: @ EPITA Rennes
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/contravariance-intuition-building.md
+++ b/public/conferences/nantes-2024/contravariance-intuition-building.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: contravariance-intuition-building
 - Category: Modeling
+- confirmed: true
 - DateTime: 2024-02-16T14:50
 - Room: 0
 - Slides: https://scala.io/slides/2024/Contravariance.pdf
@@ -34,7 +35,6 @@ We’ll begin by working with an Animal type hierarchy and some PetRescue and Pe
 
 - photoRelPath: /images/profiles/nantes-2024/sCollard.webp
 - job: Lead Software Engineer @ JPMorgan
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/data-pipelines-simple.md
+++ b/public/conferences/nantes-2024/data-pipelines-simple.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: data-pipelines-simple
 - Category: DataEng
+- confirmed: true
 - DateTime: 2024-02-16T09:50
 - Room: 0
 - Slides: https://scala.io/slides/2024/data-pipeline.pptx
@@ -20,7 +21,6 @@ Most organizations have data pipelines and those are growing by the minute. But 
 
 - photoRelPath: /images/profiles/nantes-2024/rClaude.webp
 - job: Staff Dev Lead @ Criteo
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/dependent-types-from-theory-to-practice.md
+++ b/public/conferences/nantes-2024/dependent-types-from-theory-to-practice.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: dependent-types-from-theory-to-practice
 - Category: Algebra
+- confirmed: true
 - DateTime: 2024-02-16T14:00
 - Room: 0
 - Slides: http://d.plaindoux.free.fr/talks/dependent-type/main.html
@@ -26,7 +27,6 @@ Nous aborderons: le type fonctionnel dépendant, la paire dépendante, le type s
 
 - photoRelPath: /images/profiles/nantes-2024/dPlaindoux.webp
 - job: Senior Software Engineer @ Fungus (Freelance)
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/hands-on-besom-iac-with-scala.md
+++ b/public/conferences/nantes-2024/hands-on-besom-iac-with-scala.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: hands-on-besom-iac-with-scala
 - Category: Cloud
+- confirmed: true
 - DateTime: 2024-02-16T10:50
 - Room: 0
 - Slides: https://scala.io/slides/2024/besom.pdf
@@ -20,7 +21,6 @@ In my talk I will briefly introduce Besom, a Pulumi SDK for Scala and then swift
 
 - photoRelPath: /images/profiles/nantes-2024/lBialy.webp
 - job: Software Engineer @ VirtusLab
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/intro-to-gadts.md
+++ b/public/conferences/nantes-2024/intro-to-gadts.md
@@ -3,6 +3,7 @@
 - Kind: Keynote
 - Slug: intro-to-gadts
 - Category: Algebra
+- confirmed: true
 - DateTime: 2024-02-15T09:30
 - Room: 0
 - Slides: https://scala.io/slides/2024/GADTs-xavier-vw-woestyne.pdf
@@ -20,7 +21,6 @@ Les GADTs et Scala, c’est une très longue histoire de “je t’aime, moi non
 
 - photoRelPath: /images/profiles/nantes-2024/xVdW.webp
 - job: Software Engineer @ The Funkyworkers
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/introduction-to-smithy-smithy4s.md
+++ b/public/conferences/nantes-2024/introduction-to-smithy-smithy4s.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: introduction-to-smithy-smithy4s
 - Category: Cloud
+- confirmed: true
 - DateTime: 2024-02-15T14:50
 - Room: 0
 - Slides:
@@ -26,7 +27,6 @@ This talk will serve as an introduction to the Smithy IDL, and a demo of what is
 
 - photoRelPath: /images/profiles/nantes-2024/oMelois.webp
 - job: Principal Engineer @ Disney Streaming Services
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/kapoeira-with-kafka-streams.md
+++ b/public/conferences/nantes-2024/kapoeira-with-kafka-streams.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: kapoeira-with-kafka-streams
 - Category: DataEng
+- confirmed: true
 - DateTime: 2024-02-15T16:40
 - Room: 0
 - Slides: https://jvauchel.github.io/kapoeira-dance/index-scalaio.html
@@ -30,7 +31,6 @@ Si vous êtes intéressés, nous serons ravis de récolter vos retours et vos co
 
 - photoRelPath: /images/profiles/nantes-2024/jVauchel.webp
 - job: Data Engineer @ Lectra
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/logic-meta-programming-for-functional-languages.md
+++ b/public/conferences/nantes-2024/logic-meta-programming-for-functional-languages.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: logic-meta-programming-for-functional-languages
 - Category: Algebra
+- confirmed: true
 - DateTime: 2024-02-16T09:00
 - Room: 0
 - Slides:
@@ -20,7 +21,6 @@ Since the beginning of the 21st century, the functional programming paradigm, wh
 
 - photoRelPath: /images/profiles/nantes-2024/eCrance.webp
 - job: PhD Student @ INRIA
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/migrating-gallia-to-scala-3.md
+++ b/public/conferences/nantes-2024/migrating-gallia-to-scala-3.md
@@ -3,6 +3,7 @@
 - Kind: Short
 - Slug: migrating-gallia-to-scala-3
 - Category: ToolsEcosystem
+- confirmed: true
 - DateTime: 2024-02-16T13:30
 - Room: 0
 - Slides: https://scala.io/slides/2024/gallia-migration.pdf
@@ -24,7 +25,6 @@ I will briefly introduce how certain features [worked before](https://github.com
 
 - photoRelPath: /images/profiles/nantes-2024/aCros.webp
 - job: Software Architect @ Self-employed
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/my-first-year-in-scala.md
+++ b/public/conferences/nantes-2024/my-first-year-in-scala.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: my-first-year-in-scala
 - Category: Community
+- confirmed: true
 - DateTime: 2024-02-15T17:30
 - Room: 0
 - Slides: https://scala.io/slides/2024/first-year-scala.pdf
@@ -30,7 +31,6 @@ By the end of this talk, I hope that newcomers will feel less alone and more opt
 
 - photoRelPath: /images/profiles/nantes-2024/mMcGuigan.webp
 - job: Software Engineer @ JP Morgan
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/nails-are-tree-need-chainsaw.md
+++ b/public/conferences/nantes-2024/nails-are-tree-need-chainsaw.md
@@ -3,6 +3,7 @@
 - Kind: Short
 - Slug: nails-are-tree-need-chainsaw
 - Category: Algebra
+- confirmed: true
 - DateTime: 2024-02-15T13:30
 - Room: 0
 - Slides: https://scala.io/slides/2024/Chainsaw.pdf
@@ -27,7 +28,6 @@ the process and how it helped me solved my problems with less pain.
 
 - photoRelPath: /images/profiles/nantes-2024/mBaechler.webp
 - job: Developer @ Freelancer
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/rex-migration-scala-2-to-3.md
+++ b/public/conferences/nantes-2024/rex-migration-scala-2-to-3.md
@@ -3,6 +3,7 @@
 - Kind: Lightning
 - Slug: rex-migration-scala-2-to-3
 - Category: ToolsEcosystem
+- confirmed: true
 - DateTime: 2024-02-15T18:20
 - Room: 0
 - Slides:
@@ -29,7 +30,6 @@ tout ça dans le but d'accéder au trésor : Scala 3.
 
 - photoRelPath: /images/profiles/nantes-2024/aBlondeau.webp
 - job: Developer @ Clever Cloud
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/scala-3-compiler-academy-journey.md
+++ b/public/conferences/nantes-2024/scala-3-compiler-academy-journey.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: scala-3-compiler-academy-journey
 - Category: Community
+- confirmed: true
 - DateTime: 2024-02-15T15:40
 - Room: 0
 - Slides: https://docs.google.com/presentation/d/1DPX8w7I07CIm7rU_z5TNJ_R_A7mf6_lZCMfIVBvrRpk/edit?usp=sharing
@@ -22,7 +23,6 @@ Now, two years later, with the format fleshed out and the lessons learnt, I’d 
 
 - photoRelPath: /images/profiles/nantes-2024/toli.webp
 - job: Compiler engineer and community manager @ Scala Center, EPFL
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/songwriting-in-scala-dsl-and-adt.md
+++ b/public/conferences/nantes-2024/songwriting-in-scala-dsl-and-adt.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: songwriting-in-scala-dsl-and-adt
 - Category: Modeling
+- confirmed: true
 - DateTime: 2024-02-15T14:00
 - Room: 0
 - Slides:
@@ -26,7 +27,6 @@ Topics covered:
 
 - photoRelPath: /images/profiles/nantes-2024/pMatthews.webp
 - job: Backend Scala Developer @ ClearScore
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/ukraine-scala-community.md
+++ b/public/conferences/nantes-2024/ukraine-scala-community.md
@@ -3,6 +3,7 @@
 - Kind: Lightning
 - Slug: ukraine-scala-community
 - Category: Community
+- confirmed: true
 - DateTime: 2024-02-16T16:40
 - Room: 0
 - Slides: https://scala.io/slides/2024/scala-community-building-lessons.pptx
@@ -24,7 +25,6 @@ Discover our presence at conferences, active engagement in programs such as Goog
 
 - photoRelPath: /images/profiles/nantes-2024/oMazhara.webp
 - job: Software Engineer @ Intellias
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/unleashing-scalafix-potential.md
+++ b/public/conferences/nantes-2024/unleashing-scalafix-potential.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: unleashing-scalafix-potential
 - Category: ToolsEcosystem
+- confirmed: true
 - DateTime: 2024-02-15T10:50
 - Room: 0
 - Slides: https://scala.io/slides/2024/scalafix.pdf
@@ -24,7 +25,6 @@ In this talk, we will [demystify AST traversal and semantic information lookup](
 
 - photoRelPath: /images/profiles/nantes-2024/bJaglin.webp
 - job: Staff Engineer @ Swile
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/unwrapping-io.md
+++ b/public/conferences/nantes-2024/unwrapping-io.md
@@ -3,6 +3,7 @@
 - Kind: Keynote
 - Slug: unwrapping-io
 - Category: Effects
+- confirmed: true
 - DateTime: 2024-02-16T17:00
 - Room: 0
 - Slides: https://adamw.github.io/unwrapping-io
@@ -26,7 +27,6 @@ We will compare both the low-level aspects, as well as take a look at structured
 
 - photoRelPath: /images/profiles/nantes-2024/aWarski.webp
 - job: Co-founder @ SoftwareMill
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/nantes-2024/use-ai-in-your-programs.md
+++ b/public/conferences/nantes-2024/use-ai-in-your-programs.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: use-ai-in-your-programs
 - Category: AI
+- confirmed: true
 - DateTime: 2024-02-16T11:40
 - Room: 0
 - Slides:
@@ -22,7 +23,6 @@ Une fois ceci fait, je souhaite montrer comment utiliser un modèle en utilisant
 
 - photoRelPath: /images/profiles/nantes-2024/fLaroche.webp
 - job: Tech Lead @ NuMind
-- confirmed: true
 
 #### Links
 
@@ -41,7 +41,6 @@ Je suis actuellement développeur chez NuMind où nous aidons nos clients à ent
 
 - photoRelPath: /images/profiles/nantes-2024/sBernard.webp
 - job: Co-Founder & CTO @ NuMind
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/paris-2024/how-functional-is-direct-style.md
+++ b/public/conferences/paris-2024/how-functional-is-direct-style.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: how-functional-is-direct-style
 - Category: Other
+- confirmed: true
 
 ## Abstract
 
@@ -20,7 +21,6 @@ We’ll investigate what functional programming is at its core, how it relates t
 
 - photoRelPath: /images/profiles/paris-2024/aWarski.webp
 - job: Co-founder @ SoftwareMill
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/paris-2024/plowing-postgres.md
+++ b/public/conferences/paris-2024/plowing-postgres.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: plowing-postgres-and-unearthing-hidden-gems
 - Category: Other
+- confirmed: true
 
 ## Abstract
 

--- a/public/conferences/paris-2024/regular-pattern-heterogeneous-sequences.md
+++ b/public/conferences/paris-2024/regular-pattern-heterogeneous-sequences.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: recognizing-regular-patterns-in-heterogeneous-sequences
 - Category: Other
+- confirmed: true
 
 ## Abstract
 
@@ -44,7 +45,6 @@ The project is available [here](https://github.com/jimka2001/scala-rte)
 
 - photoRelPath: /images/profiles/paris-2024/jim.webp
 - job: Researcher @ EPITA Le Kremlin-Bicêtre
-- confirmed: true
 
 #### Links
 

--- a/public/conferences/paris-2024/when-to-betray-fp-principles.md
+++ b/public/conferences/paris-2024/when-to-betray-fp-principles.md
@@ -3,6 +3,7 @@
 - Kind: Talk
 - Slug: scala-performance-when-you-should-betray-fp-principles
 - Category: Other
+- confirmed: true
 
 ## Abstract
 
@@ -18,7 +19,6 @@ Of course, Iâ€™ll bring a few benchmarks to show the differences. And while weâ€
 
 - photoRelPath: /images/profiles/paris-2024/gRenoux.webp
 - job: Staff Engineer @ DataDome
-- confirmed: true
 
 #### Links
 

--- a/src/main/resources/css/main.scss
+++ b/src/main/resources/css/main.scss
@@ -61,6 +61,12 @@ body {
   background: vars.$background-color;
 }
 
+#app > div {
+  display: flex;
+  flex-direction: column;
+  min-height: 100lvh;
+}
+
 .catch-phrase {
   margin-bottom: vars.$spacing-small;
 }

--- a/src/main/resources/css/modules/_lists.scss
+++ b/src/main/resources/css/modules/_lists.scss
@@ -28,8 +28,13 @@ $list-item-spacing: 0.25rem;
 
   li {
     display: inline;
-    margin-right: 0.5rem;
     margin-left: 0.5rem;
+    &:not(:first-child) {
+      &::before {
+        content: '|';
+        margin-right: 0.5rem;
+      }
+    }
 
     &:first-child {
       margin-left: 0;

--- a/src/main/resources/css/views/_index.scss
+++ b/src/main/resources/css/views/_index.scss
@@ -3,7 +3,7 @@
 @use "../base/mixins";
 
 .hero {
-  height: calc(100dvh - vars.$header-height);
+  height: calc(100lvh - vars.$header-height);
   .event-date-location {
     font-size: vars.$text-size-large;
   }

--- a/src/main/scala/io/scala/Page.scala
+++ b/src/main/scala/io/scala/Page.scala
@@ -179,7 +179,7 @@ object Page {
       .collectStatic(FAQPage)(FAQView.render())
       .collectStatic(CoCPage)(CoCView.render())
 
-  def navigateTo(page: Page): Binder[HtmlElement] = Binder { el =>
+  def navigateTo(page: => Page): Binder[HtmlElement] = Binder { el =>
     val isLinkElement = el.ref.isInstanceOf[html.Anchor]
     if (isLinkElement) {
       el.amend(href(router.absoluteUrlForPage(page)))

--- a/src/main/scala/io/scala/app/talks/TalkList.scala
+++ b/src/main/scala/io/scala/app/talks/TalkList.scala
@@ -33,7 +33,7 @@ case object TalkList extends ReactiveView[TalksPage] {
   override def body(args: Signal[TalksPage]): HtmlElement =
     def talksForConf(conference: Option[String], draft: Boolean) =
       if draft then TalksHistory.talksForConf(conference)
-      else TalksHistory.talksForConf(conference).filter(_.speakers.forall(_.confirmed))
+      else TalksHistory.talksForConf(conference).filter(_.info.confirmed)
 
     sectionTag(
       className := "container talks-list",

--- a/src/main/scala/io/scala/app/talks/TalkView.scala
+++ b/src/main/scala/io/scala/app/talks/TalkView.scala
@@ -4,48 +4,35 @@ import com.raquo.laminar.api.L.*
 
 import io.scala.TalkPage
 import io.scala.data.TalksHistory
+import io.scala.modules.elements.Paragraphs
+import io.scala.modules.elements.Titles
 import io.scala.svgs.Icons
 import io.scala.views.ReactiveView
 
 object TalkView extends ReactiveView[TalkPage]:
   def body(signal: Signal[TalkPage]): HtmlElement =
-    val talk = signal.map: args =>
+    val talkSignal = signal.map: args =>
       TalksHistory.talksForConf(Some(args.conference)).find(_.info.slug == args.slug).get
     sectionTag(
       className := "container talk",
-      h1( // TODO: reuse Title(name: String)
-        child.text <-- talk.map(_.info.title),
-        className := "page-title"
-      ),
-      div(
-        className := "talk-description",
-        div(
-          className := "paragraph",
-          children <-- talk.map(_.renderDescription)
-        ),
-        div(
-          className := "links",
-          child <-- talk.map:
-            _.info.slides
-              .collect:
-                case slides if slides.size > 0 =>
-                  a(Icons.pdf, href := slides, "Slides", target := "_blank")
-              .getOrElse(emptyNode)
-          ,
-          child <-- talk.map:
-            _.info.replay
-              .collect:
-                case replayUrl if replayUrl.size > 0 =>
-                  a(Icons.youtube, href := replayUrl, "Replay", target := "_blank")
-              .getOrElse(emptyNode)
+      children <-- talkSignal.map: talk =>
+        Seq(
+          Titles(talk.info.title),
+          div(
+            className := "talk-description",
+            Paragraphs.description(talk.renderDescription),
+            div(
+              className := "links",
+              talk.info.slides.fold(emptyNode): slides =>
+                a(Icons.pdf, href := slides, "Slides", target := "_blank"),
+              talk.info.replay.fold(emptyNode): replayUrl =>
+                a(Icons.youtube, href := replayUrl, "Replay", target := "_blank")
+            )
+          ),
+          Titles(if talk.speakers.size > 1 then "Speakers" else "Speaker"),
+          div(
+            className := "card-container",
+            talk.speakers.map(SpeakerView(_).body)
+          )
         )
-      ),
-      h1(
-        child.text <-- talk.map(t => if t.speakers.size > 1 then "Speakers" else "Speaker"),
-        className := "page-title"
-      ),
-      div(
-        className := "card-container",
-        children <-- talk.map(_.speakers.map(SpeakerView(_).body))
-      )
     )

--- a/src/main/scala/io/scala/data/History.scala
+++ b/src/main/scala/io/scala/data/History.scala
@@ -1,10 +1,10 @@
 package io.scala.data
 
-import scala.collection.mutable.HashMap as MutableMap
-
 import io.scala.data.parsers.Parsers
 import io.scala.models.Sponsor
 import io.scala.models.Talk
+
+import scala.collection.mutable.HashMap as MutableMap
 
 val current = "paris-2024"
 object TalksHistory:

--- a/src/main/scala/io/scala/data/ScheduleInfo.scala
+++ b/src/main/scala/io/scala/data/ScheduleInfo.scala
@@ -1,14 +1,26 @@
 package io.scala.data
 
+import java.time.DayOfWeek
+import java.time.LocalDateTime
 import java.time.LocalTime
 
+import io.scala.extensions.*
 import io.scala.models.Act
+import io.scala.models.CompleteAct
+import io.scala.models.Talk
 
+type TimeDefinedTalk = { val dateTime: LocalDateTime; val time: LocalTime; val day: DayOfWeek }
 object ScheduleInfo {
   val breaks: List[Act] = List()
 
-  val minStart      = LocalTime.of(9, 0)
-  val maxEnd        = LocalTime.of(19, 0)
-  val pxByHour      = 600
-  lazy val schedule = TalksHistory.talksForConf(None)
+  val minStart                          = LocalTime.of(9, 0)
+  val maxEnd                            = LocalTime.of(19, 0)
+  val pxByHour                          = 600
+  val foo: List[Talk & TimeDefinedTalk] = ???
+  val bar: List[CompleteAct]            = foo
+  lazy val schedule: Seq[CompleteAct] =
+    TalksHistory
+      .talksForConf(None)
+      .keepAs:
+        case t: Talk if t.info.dateTime.isDefined => t.asInstanceOf[Talk & TimeDefinedTalk]
 }

--- a/src/main/scala/io/scala/data/parsers/Parsers.scala
+++ b/src/main/scala/io/scala/data/parsers/Parsers.scala
@@ -106,6 +106,7 @@ object Parsers:
             infoMap("Slug"),
             Talk.Kind.valueOf(infoMap("Kind")),
             infoMap("Category"),
+            infoMap.get("confirmed").map(_.toBoolean).getOrElse(false),
             infoMap.get("DateTime").map(LocalDateTime.parse(_, ISO_LOCAL_DATE_TIME)),
             infoMap.get("Room").map(Talk.Room(_)),
             infoMap.get("Slides"),
@@ -132,7 +133,6 @@ object Parsers:
             name,
             infoMap("photoRelPath"),
             infoMap("job"),
-            infoMap.get("confirmed").map(_.toBoolean).getOrElse(false),
             socialsMap.map { case (name, link) =>
               Social(Social.Kind.valueOf(name), link.stripSuffix("/"))
             }.toList,

--- a/src/main/scala/io/scala/data/parsers/Parsers.scala
+++ b/src/main/scala/io/scala/data/parsers/Parsers.scala
@@ -14,6 +14,7 @@ import io.scala.models.Social
 import io.scala.models.Sponsor
 import io.scala.models.Talk
 import io.scala.modules.elements.Links
+import io.scala.extensions.*
 
 val linkExtractorRegex = """\(([^\(\)]+)\)""".r
 def extractLink(link: String) =
@@ -107,10 +108,10 @@ object Parsers:
             Talk.Kind.valueOf(infoMap("Kind")),
             infoMap("Category"),
             infoMap.get("confirmed").map(_.toBoolean).getOrElse(false),
-            infoMap.get("DateTime").map(LocalDateTime.parse(_, ISO_LOCAL_DATE_TIME)),
-            infoMap.get("Room").map(Talk.Room(_)),
-            infoMap.get("Slides"),
-            infoMap.get("Replay")
+            infoMap.getOrElse("DateTime", null).nullMap(LocalDateTime.parse(_, ISO_LOCAL_DATE_TIME)),
+            infoMap.getOrElse("Room", null).nullMap(Talk.Room(_)),
+            Talk.BasicInfo.Slides(infoMap.get("Slides")),
+            Talk.BasicInfo.Replay(infoMap.get("Replay"))
           )
         case chunk =>
           console.log(s"Error while parsing ${chunk._1.content}")

--- a/src/main/scala/io/scala/extensions/Extensions.scala
+++ b/src/main/scala/io/scala/extensions/Extensions.scala
@@ -1,0 +1,20 @@
+package io.scala.extensions
+
+extension [T](x: T | Null)
+  inline def isEmpty = x == null
+  inline def isDefined = x != null
+  inline def nullToOption: Option[T] =
+    if x == null then None else Some(x)
+  inline def nullMap[U](f: T => U): U | Null = 
+    if x != null then f(x) else null
+  inline def nullFlatMap[U](f: T => U | Null): U | Null = 
+    if x != null then f(x) else null
+  inline def nullGetOrElse[U >: T](default: => U): U =
+    if x == null then default else x
+  inline def nullOrElse[U >: T](alternative: => U | Null): U | Null =
+    if x == null then alternative else x
+  inline def nullFold[U](ifNull: => U)(f: T => U): U = 
+    if x == null then ifNull else f(x)
+
+extension [T](xs: Seq[T])
+  def keepAs[U](f: PartialFunction[T, T & U]): Seq[T & U] = xs.collect(f)

--- a/src/main/scala/io/scala/models/Talk.scala
+++ b/src/main/scala/io/scala/models/Talk.scala
@@ -36,12 +36,12 @@ case class Talk(
     with Durable:
   lazy val renderDescription = Parsers.Description.parseTalk(description).map(Paragraphs.description(_))
 
-  def dateTime: Option[LocalDateTime] = info.dateTime
-  val day                            = info.dateTime.map(_.getDayOfWeek)
-  val time                           = info.dateTime.map(_.toLocalTime)
-  def duration: Int                  = info.kind.duration
-  def render: Div                    = TalkCard(this, current)
-  def isKeynote: Boolean             = info.kind == Talk.Kind.Keynote
+  def dateTime      = info.dateTime
+  val day           = info.dateTime.map(_.getDayOfWeek)
+  val time          = info.dateTime.map(_.toLocalTime)
+  def duration: Int = info.kind.duration
+  def render: Div   = TalkCard(this, current)
+  def isKeynote     = info.kind == Talk.Kind.Keynote
 
 object Talk:
   opaque type Room = String
@@ -70,19 +70,19 @@ object Talk:
       slug: String,
       kind: Kind,
       category: String,
+      confirmed: Boolean,
       dateTime: Option[LocalDateTime],
       room: Option[Room] = None, // TODO: reuse String | Null
       slides: Option[String] = None,
       replay: Option[String] = None
   )
   object BasicInfo:
-    def empty = BasicInfo("Malformed talk info", "", Kind.Talk, "", None)
+    def empty = BasicInfo("Malformed talk info", "", Kind.Talk, "", false, None)
 
   case class Speaker(
       name: String,
       photoRelPath: String,
       job: String,
-      confirmed: Boolean = false,
       socials: List[Social] = List.empty,
       bio: String = ""
   ):
@@ -101,9 +101,9 @@ case class Break(
     overrideDuration: Option[Int] = None
 ) extends Act
     with Durable:
-  def duration: Int          = overrideDuration.getOrElse(kind.duration)
-  val day  = dateTime.map(_.getDayOfWeek)
-  val time = dateTime.map(_.toLocalTime)
+  def duration: Int = overrideDuration.getOrElse(kind.duration)
+  val day           = dateTime.map(_.getDayOfWeek)
+  val time          = dateTime.map(_.toLocalTime)
   def render =
     div(className := s"blank-card break ${kind.style}", kind.icon, span(span(duration), span("min")), kind.icon)
 

--- a/src/main/scala/io/scala/models/Talk.scala
+++ b/src/main/scala/io/scala/models/Talk.scala
@@ -10,6 +10,7 @@ import org.scalajs.dom.HTMLDivElement
 
 import io.scala.data.current
 import io.scala.data.parsers.Parsers
+import io.scala.extensions.*
 import io.scala.modules.TalkCard
 import io.scala.modules.elements.Paragraphs
 import io.scala.svgs.Icons
@@ -20,9 +21,10 @@ sealed trait TalkInfo[A <: TalkInfo[A]]:
 object TalkInfo:
   given [A <: TalkInfo[A]]: Ordering[A] = Ordering[Int].on(_.ordinal)
 
+type CompleteAct = Act & { val time: LocalTime; val day: DayOfWeek }
 sealed trait Act:
-  def day: Option[DayOfWeek]
-  def time: Option[LocalTime]
+  def day: DayOfWeek | Null
+  def time: LocalTime | Null
   def render: Div
 
 sealed trait Durable:
@@ -36,9 +38,8 @@ case class Talk(
     with Durable:
   lazy val renderDescription = Parsers.Description.parseTalk(description).map(Paragraphs.description(_))
 
-  def dateTime      = info.dateTime
-  val day           = info.dateTime.map(_.getDayOfWeek)
-  val time          = info.dateTime.map(_.toLocalTime)
+  val day           = info.dateTime.nullMap(_.getDayOfWeek)
+  val time          = info.dateTime.nullMap(_.toLocalTime)
   def duration: Int = info.kind.duration
   def render: Div   = TalkCard(this, current)
   def isKeynote     = info.kind == Talk.Kind.Keynote
@@ -49,6 +50,7 @@ object Talk:
   object Room:
     def empty                     = "TBD"
     def apply(room: String): Room = room
+    given Ordering[Room]          = Ordering.String.on(_.show)
 
   def empty            = Talk(BasicInfo.empty, "To be announced", List.empty)
   given Ordering[Talk] = Ordering.by(talk => (talk.info.kind, talk.info.title))
@@ -71,13 +73,23 @@ object Talk:
       kind: Kind,
       category: String,
       confirmed: Boolean,
-      dateTime: Option[LocalDateTime],
-      room: Option[Room] = None, // TODO: reuse String | Null
-      slides: Option[String] = None,
-      replay: Option[String] = None
+      dateTime: LocalDateTime | Null,
+      room: Room | Null, // TODO: reuse String | Null
+      slides: BasicInfo.Slides = None,
+      replay: BasicInfo.Replay = None
   )
   object BasicInfo:
-    def empty = BasicInfo("Malformed talk info", "", Kind.Talk, "", false, None)
+    def empty = BasicInfo("Malformed talk info", "", Kind.Talk, "", false, null, null)
+
+    opaque type Slides = Option[String]
+    object Slides:
+      extension (slides: Slides) inline def fold[A](ifEmpty: => A)(f: String => A): A = slides.fold(ifEmpty)(f)
+      inline def apply(opt: Option[String]): Slides = opt.filter(_.size > 0)
+
+    opaque type Replay = Option[String]
+    object Replay:
+      extension (replay: Replay) inline def fold[A](ifEmpty: => A)(f: String => A): A = replay.fold(ifEmpty)(f)
+      inline def apply(opt: Option[String]): Replay = opt.filter(_.size > 0)
 
   case class Speaker(
       name: String,
@@ -96,14 +108,14 @@ object Talk:
     def empty = Speaker("Malformed speaker", "", "")
 
 case class Break(
-    dateTime: Option[LocalDateTime],
+    dateTime: LocalDateTime,
     kind: Break.Kind,
     overrideDuration: Option[Int] = None
 ) extends Act
     with Durable:
   def duration: Int = overrideDuration.getOrElse(kind.duration)
-  val day           = dateTime.map(_.getDayOfWeek)
-  val time          = dateTime.map(_.toLocalTime)
+  val day           = dateTime.nullMap(_.getDayOfWeek)
+  val time          = dateTime.nullMap(_.toLocalTime)
   def render =
     div(className := s"blank-card break ${kind.style}", kind.icon, span(span(duration), span("min")), kind.icon)
 
@@ -120,11 +132,11 @@ object Break:
     val max: Int = Kind.values.map(_.duration).max
 
 case class Special(
-    dateTime: Option[LocalDateTime],
+    dateTime: LocalDateTime,
     kind: Special.Kind
 ) extends Act {
-  val day  = dateTime.map(_.getDayOfWeek)
-  val time = dateTime.map(_.toLocalTime)
+  val day  = dateTime.nullMap(_.getDayOfWeek)
+  val time = dateTime.nullMap(_.toLocalTime)
   def render: ReactiveHtmlElement[HTMLDivElement] = kind match
     case Special.Kind.End => div(className := "blank-card end-day", Icons.logo("#222222"))
 }

--- a/src/main/scala/io/scala/modules/TalkCard.scala
+++ b/src/main/scala/io/scala/modules/TalkCard.scala
@@ -10,6 +10,7 @@ import org.scalajs.dom.HTMLSpanElement
 
 import io.scala.models.Talk
 import io.scala.svgs.Icons
+import io.scala.extensions.*
 
 object TalkKindTag:
   def apply(kind: Talk.Kind): ReactiveHtmlElement[HTMLSpanElement] =
@@ -32,7 +33,7 @@ object TalkCard:
         ),
         div(
           className := "subtitle",
-          talk.info.room.fold(emptyNode)(room => span(className := "room", room.show))
+          talk.info.room.nullFold(emptyNode)(room => span(className := "room", room.show))
         )
       ),
       Line(margin = 16),

--- a/src/main/scala/io/scala/modules/elements/Lists.scala
+++ b/src/main/scala/io/scala/modules/elements/Lists.scala
@@ -21,7 +21,7 @@ object Lists:
   def pipes(elements: ReactiveHtmlElement[HTMLElement]*) =
     ul(
       className := "list-pipes",
-      elements.flatMap(Seq(_, span("|"))).dropRight(1)
+      elements.map(li(_))
     )
 
   def titledItem(title: String, content: Modifier[ReactiveHtmlElement[HTMLLIElement]]) =

--- a/src/main/scala/io/scala/modules/layout/Footer.scala
+++ b/src/main/scala/io/scala/modules/layout/Footer.scala
@@ -66,7 +66,7 @@ object Footer {
                       case index: IndexPage       => index.copy(conference = Some(linkKey))
                       case talks: TalksPage       => talks.copy(conference = Some(linkKey))
                       case sponsors: SponsorsPage => sponsors.copy(conference = Some(linkKey))
-                      case page                   => page
+                      case page                   => TalksPage(conference = Some(linkKey))
                   },
                   href := s"?conference=${key.replace("_", "-")}"
                 )

--- a/src/main/scala/io/scala/modules/layout/Footer.scala
+++ b/src/main/scala/io/scala/modules/layout/Footer.scala
@@ -2,7 +2,6 @@ package io.scala.modules.layout
 
 import com.raquo.laminar.api.L.*
 import com.raquo.laminar.nodes.ReactiveHtmlElement
-
 import io.scala.IndexPage
 import io.scala.Lexicon
 import io.scala.Page
@@ -67,8 +66,7 @@ object Footer {
                       case talks: TalksPage       => talks.copy(conference = Some(linkKey))
                       case sponsors: SponsorsPage => sponsors.copy(conference = Some(linkKey))
                       case page                   => TalksPage(conference = Some(linkKey))
-                  },
-                  href := s"?conference=${key.replace("_", "-")}"
+                  }
                 )
             )
           }*

--- a/src/main/scala/io/scala/views/EventsView.scala
+++ b/src/main/scala/io/scala/views/EventsView.scala
@@ -19,10 +19,12 @@ object EventsView extends SimpleView {
     sectionTag(
       className := "container events",
       Titles("Other events"),
-      Containers.flexCards(events.zipWithIndex.map { (ev, idx) =>
-        if idx % 2 == 0 then ev.render.amend(className := "normal")
-        else ev.render.amend(className := "reverse")
-      })
+      Containers.flexCards {
+        events.zipWithIndex.map { case (ev, idx) =>
+          if idx % 2 == 0 then ev.render.amend(className := "normal")
+          else ev.render.amend(className := "reverse")
+        }
+      }
     )
   }
 }

--- a/src/main/scala/io/scala/views/IndexView.scala
+++ b/src/main/scala/io/scala/views/IndexView.scala
@@ -17,23 +17,13 @@ case object IndexView extends ReactiveView[IndexPage] {
       IndexView.hero,
       sectionTag(
         div(
-          className := "container description",
+          className := "container",
           Titles("Exchanging Ideas"),
-          p("""
-                Scala.IO is a conference for people having
-                 interest in the Scala ecosystem or simply
-                 being curious about the language, usages.
-
-                """),
-          p(
-            """The conference is organized by Scala supporters from the community,
-                | and provides a great opportunity to meet with other enthusiasts and practitioners.""".stripMargin,
-            "You can find the videos of the past editions (200+) on our ",
-            Links.highlighted(href := "https://www.youtube.com/@scalaio/videos", "YouTube channel"),
-            "."
+          Paragraphs.description(
+            "Scala.IO is a conference for people having interest in the Scala ecosystem or simply being curious about the language, usages. The conference is organized by Scala supporters from the community, and provides a great opportunity to meet with other enthusiasts and practitioners. You can find the videos of the past editions (200+) on our ",
+            Links.highlighted(href := "https://www.youtube.com/@scalaio/videos", "YouTube channel")
           ),
-          br(),
-          p(
+          Paragraphs.description(
             "This edition brings us together in Paris for two days, with a multi-session structure and a large community space. With a great venue, wonderful speakers, and a lot of surprises, we are looking forward to meeting you there!"
           )
         ),
@@ -48,7 +38,7 @@ case object IndexView extends ReactiveView[IndexPage] {
     def speakers(conf: Option[String]) =
       TalksHistory
         .talksForConf(conf)
-        .filter(_.speakers.forall(_.confirmed)) // TODO: move the confirmed to the talk level
+        .filter(_.info.confirmed)
         .flatMap: talk =>
           talk.speakers.map((_, talk.info))
         .sortBy(_._1.name)


### PR DESCRIPTION
- **moved confirmation status to talk model**
- **added explicit null, partly fixed footer navigation & simplified some views**
- **fixed footer edition navigation**

Moved talk confirmation status to the talk's level
Added explicit null and played with refined types to avoid having to do `Option#get` or create unneeded collection
Used the above to simplify some views
Fixed footer navigation (the edition switch was stuck to the same page after 1st evaluation)
