### PR TITLE
Schedule switches

### DIFF
--- a/public/conferences/paris-2024/building-robust-applications-with-kyo-intro.md
+++ b/public/conferences/paris-2024/building-robust-applications-with-kyo-intro.md
@@ -6,7 +6,7 @@ id: kyo-talk
 
 - Kind: Short
 - Slug: building-robust-applications-with-kyo-intro
-- Category: Effect Systems
+- Category: Tools & Ecosystem
 - confirmed: true
 - DateTime: 2024-11-07T10:45:00
 - Room: A

--- a/public/conferences/paris-2024/calculating-funnier.md
+++ b/public/conferences/paris-2024/calculating-funnier.md
@@ -4,7 +4,7 @@
 - Slug: calculating-is-funnier-than-guessing
 - Category: Algebra
 - confirmed: true
-- DateTime: 2024-11-07T16:30:00
+- DateTime: 2024-11-07T15:30:00
 - Room: B
 
 ## Abstract

--- a/public/conferences/paris-2024/computer-algebra-scala.md
+++ b/public/conferences/paris-2024/computer-algebra-scala.md
@@ -4,8 +4,8 @@
 - Slug: computer-algebra-scala
 - Category: Algebra
 - confirmed: true
-- DateTime: 2024-11-07T11:30:00
-- Room: A
+- DateTime: 2024-11-07T14:30:00
+- Room: B
 
 ## Abstract
 

--- a/public/conferences/paris-2024/contextual-abstraction-scala3.md
+++ b/public/conferences/paris-2024/contextual-abstraction-scala3.md
@@ -4,8 +4,8 @@
 - Slug: say-goodbye-to-implicits-contextual-abstractions-in-scala3
 - Category: Language
 - confirmed: true
-- DateTime: 2024-11-07T14:30:00
-- Room: B
+- DateTime: 2024-11-07T11:30:00
+- Room: A
 
 ## Abstract
 

--- a/public/conferences/paris-2024/decision4s.md
+++ b/public/conferences/paris-2024/decision4s.md
@@ -5,7 +5,7 @@
 - Category: Language
 - confirmed: true
 - DateTime: 2024-11-08T14:30:00
-- Room: A
+- Room: B
 
 ## Abstract
 

--- a/public/conferences/paris-2024/escaping-false-dichotomy.md
+++ b/public/conferences/paris-2024/escaping-false-dichotomy.md
@@ -5,7 +5,7 @@
 - Category: Language
 - confirmed: true
 - DateTime: 2024-11-07T16:30:00
-- Room: B
+- Room: A
 
 ## Abstract
 

--- a/public/conferences/paris-2024/escaping-false-dichotomy.md
+++ b/public/conferences/paris-2024/escaping-false-dichotomy.md
@@ -4,7 +4,7 @@
 - Slug: escaping-false-dichotomy-with-sanely-automatic-derivation
 - Category: Language
 - confirmed: true
-- DateTime: 2024-11-07T15:30:00
+- DateTime: 2024-11-07T16:30:00
 - Room: B
 
 ## Abstract

--- a/public/conferences/paris-2024/regular-pattern-heterogeneous-sequences.md
+++ b/public/conferences/paris-2024/regular-pattern-heterogeneous-sequences.md
@@ -5,7 +5,7 @@
 - Category: Algebra
 - confirmed: true
 - DateTime: 2024-11-07T16:30:00
-- Room: A
+- Room: B
 
 ## Abstract
 

--- a/public/conferences/paris-2024/when-to-betray-fp-principles.md
+++ b/public/conferences/paris-2024/when-to-betray-fp-principles.md
@@ -5,7 +5,7 @@
 - Category: Language
 - confirmed: true
 - DateTime: 2024-11-08T14:30:00
-- Room: B
+- Room: A
 
 ## Abstract
 


### PR DESCRIPTION
Pour éviter que 2 talks estampillés "Algebra" / metaprogramming aient lieu en même temps :
- switch escaping false dichotomy and Calculating is funnier than guessing
- switch Say goodbye to implicits and Computer algebra in Scala 